### PR TITLE
COL-346 Return alternate embeddable URLs from preview service

### DIFF
--- a/lib/preview/link.js
+++ b/lib/preview/link.js
@@ -24,6 +24,7 @@
  */
 
 var _ = require('lodash');
+var htmlparser = require('htmlparser2');
 var path = require('path');
 var request = require('request');
 var url = require('url');
@@ -35,6 +36,11 @@ var CoreUtil = require('../core/util');
 var PreviewConstants = require('./constants');
 var PreviewImage = require('./image');
 var Result = require('./model').Result;
+
+// URLs matching any of these regexes will be cheched for an "embedURL" meta tag.
+var CHECK_EMBED_URL_REGEXES = [
+  /^http(s)?:\/\/(drive|docs)\.google\.com\//
+];
 
 // URLs matching any of these regexes will be marked "not embeddable" over all protocols.
 var DISALLOW_EMBED_REGEXES = [
@@ -149,7 +155,7 @@ var processLink = function(ctx, link, callback) {
       }
 
       // Check whether the link can be embedded as an iframe
-      isIframeEmbeddable(link, function(err, httpEmbeddable, httpsEmbeddable) {
+      isIframeEmbeddable(link, function(err, httpEmbeddable, httpsEmbeddable, httpEmbedUrl, httpsEmbedUrl) {
         if (err) {
           return callback(err);
         }
@@ -157,6 +163,8 @@ var processLink = function(ctx, link, callback) {
         var metadata = {
           'httpEmbeddable': httpEmbeddable,
           'httpsEmbeddable': httpsEmbeddable,
+          'httpEmbedUrl': httpEmbedUrl,
+          'httpsEmbedUrl': httpsEmbedUrl,
           'image_width': 1280
         };
         var result = new Result(PreviewConstants.STATUS.DONE, thumbnailPath, imagePath, null, metadata);
@@ -174,6 +182,8 @@ var processLink = function(ctx, link, callback) {
  * @param  {Object}     callback.err                  An error object, if any
  * @param  {Boolean}    callback.httpEmbeddable       Whether the link is embeddable in an iframe over HTTP
  * @param  {Boolean}    callback.httpsEmbeddable      Whether the link is embeddable in an iframe over HTTPS
+ * @param  {String}     [callback.httpEmbedUrl]       Alternate URL, if any, for HTTP iframe embedding
+ * @param  {String}     [callback.httpsEmbedUrl]      Alternate URL, if any, for HTTPS iframe embedding
  * @api private
  */
 var isIframeEmbeddable = function(link, callback) {
@@ -185,17 +195,17 @@ var isIframeEmbeddable = function(link, callback) {
     return callback(null, false, false);
   }
 
-  isIframeEmbeddableOnProtocol(link, 'http', function(err, httpEmbeddable) {
+  isIframeEmbeddableOnProtocol(link, 'http', function(err, httpEmbeddable, httpEmbedUrl) {
     if (err) {
       return callback(err);
     }
 
-    isIframeEmbeddableOnProtocol(link, 'https', function(err, httpsEmbeddable) {
+    isIframeEmbeddableOnProtocol(link, 'https', function(err, httpsEmbeddable, httpsEmbedUrl) {
       if (err) {
         return callback(err);
       }
 
-      return callback(null, httpEmbeddable, httpsEmbeddable);
+      return callback(null, httpEmbeddable, httpsEmbeddable, httpEmbedUrl, httpsEmbedUrl);
     });
   });
 };
@@ -207,7 +217,8 @@ var isIframeEmbeddable = function(link, callback) {
  * @param  {String}       protocol                      The protocol on which to embed the link. One of `http` or `https`
  * @param  {Function}     callback                      Standard callback function
  * @param  {Object}       callback.err                  An error object, if any
- * @param  {Boolean}      callback.httpEmbeddable       Whether the link is embeddable in an iframe over the specified protocol
+ * @param  {Boolean}      callback.embeddable           Whether the link is embeddable in an iframe over the specified protocol
+ * @param  {String}       [callback.embedUrl]           Alternate URL, if any, for iframe embedding over the specified protocol
  * @api private
  */
 var isIframeEmbeddableOnProtocol = function(link, protocol, callback) {
@@ -225,21 +236,59 @@ var isIframeEmbeddableOnProtocol = function(link, protocol, callback) {
       return callback(null, false);
     }
 
+    var embedUrl = null;
+
     // Ensure all intermediary links stayed on the same protocol
     // and none of them disallowed framing
     var badResponse = _.find(responses, function(response) {
-      if (_.has(response.headers, 'x-frame-options')) {
+      if (response.request.uri.protocol !== expectedProtocol) {
         return true;
-      } else if (response.request.uri.protocol !== expectedProtocol) {
+      } else if (_.has(response.headers, 'x-frame-options')) {
+        embedUrl = checkEmbedUrl(response.request.uri.href, response.body, expectedProtocol);
         return true;
       } else {
         return false;
       }
     });
 
-    var isEmbeddable = (!badResponse);
-    return callback(null, isEmbeddable);
+    var isEmbeddable = embedUrl ? true : !badResponse;
+    return callback(null, isEmbeddable, embedUrl);
   });
+};
+
+/**
+ * Parse HTML response body in search of an embedURL meta tag. Since this is potentially
+ * expensive and these tags only show up in a few sources, we perform the parse only for
+ * URLs matching a whitelisted regex.
+ *
+ * @param  {String}       link                      The link to resolve
+ * @param  {Function}     callback                  Standard callback function
+ * @param  {Boolean}      callback.resolvable       Whether the link can be resolved
+ * @return {String}       embedUrl                  Alternate embeddable URL, if any
+ * @api private
+ */
+var checkEmbedUrl = function(url, body, expectedProtocol) {
+  var shouldCheckEmbedUrl = _.find(CHECK_EMBED_URL_REGEXES, function(regex) {
+    return regex.test(url);
+  });
+
+  if (!shouldCheckEmbedUrl) {
+    return null;
+  }
+
+  var embedUrl = null;
+  var parseEvents = {
+    'onopentag': function(name, attribs) {
+      if (name === 'meta' && attribs.itemprop === 'embedURL' && attribs.content && attribs.content.lastIndexOf(expectedProtocol) === 0) {
+        embedUrl = attribs.content;
+      }
+    }
+  };
+  var parser = new htmlparser.Parser(parseEvents, {'decodeEntities': true});
+  parser.write(body);
+  parser.end();
+
+  return embedUrl;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gm": "1.22.0",
     "gulp": "3.9.0",
     "gulp-jscs": "2.0.0",
+    "htmlparser2": "3.9.2",
     "mmmagic": "0.4.4",
     "request": "2.72.0",
     "shortid": "2.2.6",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-346

Right now we're only aware of Google Drive using this embedURL attribute, but it may show up elsewhere.

Goes together with https://github.com/ets-berkeley-edu/suitec/pull/223