### PR TITLE
COL-346 Avoid embed checks on every step of a redirect path

### DIFF
--- a/lib/preview/link.js
+++ b/lib/preview/link.js
@@ -339,22 +339,30 @@ var isIframeEmbeddableOnProtocol = function(link, protocol, callback) {
       return callback(null, false);
     }
 
+    var response = _.last(responses);
+    if (!response) {
+      return callback(null, false);
+    }
+
     var embedUrl = null;
+    var isEmbeddable = true;
 
-    // Ensure all intermediary links stayed on the same protocol
-    // and none of them disallowed framing
-    var badResponse = _.find(responses, function(response) {
-      if (response.request.uri.protocol !== expectedProtocol) {
-        return true;
-      } else if (_.has(response.headers, 'x-frame-options')) {
-        embedUrl = checkEmbedUrl(response.request.uri.href, response.body, expectedProtocol);
-        return true;
-      } else {
-        return false;
-      }
-    });
+    if (response.request.uri.protocol !== expectedProtocol) {
+      // If the last-resolved URI has changed protocols, the link is not embeddable.
+      isEmbeddable = false;
 
-    var isEmbeddable = embedUrl ? true : !badResponse;
+    } else if (_.has(response.headers, 'x-frame-options')) {
+      // If the last-resolved response disallows framing, the link is embeddable only if an alternate embed URL is
+      // provided on the expected protocol.
+      embedUrl = checkEmbedUrl(response.request.uri.href, response.body, expectedProtocol);
+      isEmbeddable = !!embedUrl;
+
+    } else if (link !== response.request.uri.href) {
+      // If the initial link and last-resolved link differ (i.e., redirects took place), the last-resolved link should
+      // be provided as an alternate embed URL.
+      embedUrl = response.request.uri.href;
+    }
+
     return callback(null, isEmbeddable, embedUrl);
   });
 };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-346

The preview service currently checks for protocol changes and x-frame-options headers on every step of a redirect path. This is overly restrictive; it should suffice to run these checks on the last response only.