### PR TITLE
COL-330 Resize images to PNG; preserve transparency

### DIFF
--- a/lib/preview/image.js
+++ b/lib/preview/image.js
@@ -236,14 +236,12 @@ var cropImage = function(ctx, file, options, callback) {
  * @api private
  */
 var resizeImage = function(ctx, file, options, callback) {
-  var outputFilename = util.format('resized_%dx%d_%d.jpg', options.width, options.height, Date.now());
+  var outputFilename = util.format('resized_%dx%d_%d.png', options.width, options.height, Date.now());
   var outputFilePath = path.join(ctx.directory, outputFilename);
 
   gm(file)
     .autoOrient()
     .noProfile()
-    .flatten()
-    .background('white')
     .resize(options.width, options.height)
     .write(outputFilePath, function(err) {
       if (err) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-330

http://www.graphicsmagick.org/GraphicsMagick.html for more and gorier details than necessary. The upshot is that the `flatten` option appears to strip the alpha channel, and JPEG encoding doesn't support such a channel in any case.