### PR TITLE
COL-641, link.js gets a bit of code style love

### DIFF
--- a/lib/preview/link.js
+++ b/lib/preview/link.js
@@ -37,7 +37,7 @@ var PreviewConstants = require('./constants');
 var PreviewImage = require('./image');
 var Result = require('./model').Result;
 
-// URLs matching any of these regexes will be cheched for an "embedURL" meta tag.
+// URLs matching any of these regexes will be checked for an "embedURL" meta tag.
 var CHECK_EMBED_URL_REGEXES = [
   /^http(s)?:\/\/(drive|docs)\.google\.com\//
 ];
@@ -141,7 +141,7 @@ var processVimeo = function(ctx, vimeoUrl, callback) {
       return callback({'code': 500, 'msg': 'No response body for URL ' + vimeoUrl});
     }
 
-    // We will attempt to parse the body for these values. 
+    // We will attempt to parse the body for these values.
     var embedUrl = null;
     var imageUrl = null;
     var imageWidth = null;
@@ -293,7 +293,7 @@ var isIframeEmbeddable = function(link, callback) {
   var isEmbeddingDisallowed = _.find(DISALLOW_EMBED_REGEXES, function(regex) {
     return regex.test(link);
   });
-  
+
   if (isEmbeddingDisallowed) {
     return callback(null, false, false);
   }
@@ -372,9 +372,9 @@ var isIframeEmbeddableOnProtocol = function(link, protocol, callback) {
  * expensive and these tags only show up in a few sources, we perform the parse only for
  * URLs matching a whitelisted regex.
  *
- * @param  {String}       link                      The link to resolve
- * @param  {Function}     callback                  Standard callback function
- * @param  {Boolean}      callback.resolvable       Whether the link can be resolved
+ * @param  {String}       url                       URL namespace determines whether we check "embedURL" meta tag.
+ * @param  {String}       body                      Response body content
+ * @param  {String}       expectedProtocol          Used to identify allowable "embedURL". One of `http` or `https`
  * @return {String}       embedUrl                  Alternate embeddable URL, if any
  * @api private
  */


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-641

With this change, `jscs` should pass in our AWS CodeBuild run. 