### PR TITLE
COL-639, buildspec.yml without excessive escaping

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,35 +2,35 @@ version: 0.1
 
 environment_variables:
   plaintext:
-    DATE_FORMAT: "%F %H:%M:%S"
+    DATE_FORMAT: '%F_%H:%M:%S'
 
 phases:
   install:
     commands:
-      - "echo $(date +\"${DATE_FORMAT}\") - Begin install phase (pre-build)"
-      - "echo Install jscs..."
-      - "npm install -g jscs"
+      - 'echo "$(date +${DATE_FORMAT}): Begin install phase"'
+      - 'echo "Install jscs..."'
+      - 'npm install -g jscs'
   pre_build:
     commands:
-      - "echo $(date +\"${DATE_FORMAT}\") - Start build"
-      - "echo AWS CodeBuild src directory is ${CODEBUILD_SRC_DIR}"
-      - "npm install"
+      - 'echo "$(date +${DATE_FORMAT}): Begin pre_build phase"'
+      - 'echo "AWS CodeBuild src directory is ${CODEBUILD_SRC_DIR}"'
+      - 'npm install'
   build:
     commands:
-      - "echo $(date +\"${DATE_FORMAT}\") - Build started"
-      - "echo Run jscs..."
-      - "gulp jscs"
-      - "export VERSION=$(grep -m 1 version package.json | tr -dc '0-9\\.')"
-      - "export COMMIT=$(git rev-parse HEAD | cut -c 1-7)"
-      - "export ARTIFACT_NAME=suitec-preview-service_${VERSION}-${COMMIT}.zip"
-      - "echo Create ${ARTIFACT_NAME} (build artifact)..."
-      - "zip -r ${ARTIFACT_NAME} * -x logs\\*"
+      - 'echo "$(date +${DATE_FORMAT}): Begin build phase"'
+      - 'echo "Run jscs..."'
+      - 'gulp jscs'
+      - 'export VERSION=$(grep -m 1 version package.json | tr -dc "0-9\.")'
+      - 'export COMMIT=$(git rev-parse HEAD | cut -c 1-7)'
+      - 'export ARTIFACT_NAME="suitec-preview-service_${VERSION}-${COMMIT}.zip"'
+      - 'echo "Package as ZIP file"'
+      - 'zip -r ${ARTIFACT_NAME} * -x logs\*'
   post_build:
     commands:
-      - "echo $(date +\"${DATE_FORMAT}\") - Build completed"
-      - "echo Done. Artifact ${ARTIFACT_NAME} is ready."
+      - 'echo "$(date +${DATE_FORMAT}): Begin post_build phase"'
+      - 'echo "Artifact is ready for deployment: ${ARTIFACT_NAME}"'
 
 artifacts:
   files:
-    - "${ARTIFACT_NAME}"
+    - '${ARTIFACT_NAME}'
   discard-paths: yes


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-639

Notes:
* YAML spec supports use of single quotes as seen in this PR
* Underscore in DATE_FORMAT avoids further escaping
* Double quotes enable interpolation in shell script
