### PR TITLE
COL-629, AWS build output has timestamps per line - DATE_FORMAT not needed

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,36 +1,25 @@
 version: 0.1
 
-environment_variables:
-  plaintext:
-    DATE_FORMAT: '%F_%H:%M:%S'
-
 phases:
   install:
     commands:
-      - 'echo "$(date +${DATE_FORMAT}): Begin install phase"'
       - 'echo "Install jscs..."'
       - 'npm install -g jscs'
   pre_build:
     commands:
-      - 'echo "$(date +${DATE_FORMAT}): Begin pre_build phase"'
       - 'echo "AWS CodeBuild src directory is ${CODEBUILD_SRC_DIR}"'
       - 'npm install'
   build:
     commands:
-      - 'echo "$(date +${DATE_FORMAT}): Begin build phase"'
       - 'echo "Run jscs..."'
       - 'gulp jscs'
-      - 'export VERSION=$(grep -m 1 version package.json | tr -dc "0-9\.")'
-      - 'export COMMIT=$(git rev-parse HEAD | cut -c 1-7)'
-      - 'export ARTIFACT_NAME="suitec-preview-service_${VERSION}-${COMMIT}.zip"'
       - 'echo "Package as ZIP file"'
-      - 'zip -r ${ARTIFACT_NAME} * -x logs\*'
+      - 'zip -r "suitec-preview-service_${CODEBUILD_BUILD_ID}.zip" * -x logs\*'
   post_build:
     commands:
-      - 'echo "$(date +${DATE_FORMAT}): Begin post_build phase"'
       - 'echo "Artifact is ready for deployment: ${ARTIFACT_NAME}"'
 
 artifacts:
   files:
-    - '${ARTIFACT_NAME}'
+    - suitec-preview-service_${CODEBUILD_BUILD_ID}.zip
   discard-paths: yes


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-639

The `buildspec.yml` learning curve continues to bend. Sample from AWS build log:
```
2017/02/01 19:31:36 Entering phase INSTALL
``` 
Timestamp is provided. 