### PR TITLE
COL-658, buildspec enhancements as lessons were learned in SuiteC

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,24 +9,20 @@ eb_codebuild_settings:
 phases:
   install:
     commands:
-      - echo "NPM installs..."
-      - npm install --save-dev gulp
-      - npm install --save-dev gulp-jscs
-      - npm install --save-dev jscs
+      - npm install
   pre_build:
     commands:
-      - echo "CodeBuild src directory is ${CODEBUILD_SRC_DIR}"
+      - ./node_modules/.bin/gulp jscs
   build:
     commands:
-      - echo "Run jscs..."
-      - cd "${CODEBUILD_SRC_DIR}"
-      - ./node_modules/.bin/gulp jscs
+      - echo "build phase"
   post_build:
     commands:
-      - echo "The 'build' phase is done"
+      - rm -Rf node_modules
 
 artifacts:
   files:
-    - '.ebextensions/**/*'
-    - '.elasticbeanstalk/**/*'
+    - '.ebextensions/*'
+    - '.elasticbeanstalk/*'
+    - '.gitignore'
     - '**/*'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-658

Lessons learned from work on SuiteC's buildspec.yml (see PR #280):
* See diagram: [Build Phase Transitions](http://docs.aws.amazon.com/codebuild/latest/userguide/view-build-details.html#view-build-details-phases). You'll notice that a failure in the "build" phase does not cause CodeBuild to skip the upload_artifacts phase.  Therefore, I moved `gulp jscs` to the pre_build phase.
* The post_build phase has `rm -Rf node_modules`. We want a "clean" artifact uploaded to EB.
* Include `.gitignore` in the deployment because, according to [Amazon docs](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-configuration.html), "If no .ebignore is present... the EB CLI will ignore files specified in the .gitignore."

cc: @sandeepmjay @paulkerschen 