### PR TITLE
COL-685, preview-service buildspec.yml gets proper role and ComputeType

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,8 +1,8 @@
 version: 0.1
 
 eb_codebuild_settings:
-  CodeBuildServiceRole: arn:aws:iam::234923831700:role/service-role/code-build-suitec-preview-service-service-role
-  ComputeType: Linux
+  CodeBuildServiceRole: arn:aws:iam::234923831700:role/service-role/aws-codebuild-suitec-preview-service-role
+  ComputeType: BUILD_GENERAL1_MEDIUM
   Image: aws/codebuild/nodejs:6.3.1
   Timeout: 60
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-685

One step towards functional `eb deploy` option. I hope to solve the remaining issue ("User: arn:...aws-codebuild-suitec-preview-service-role/AWSCodeBuild is not authorized to perform: logs:CreateLogStream...") via AWS console.

I'll submit QA PR unless reviewer objects.