### PR TITLE
NOJIRA, add require(logger) because we log.error below

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -26,6 +26,7 @@
 var config = require('config');
 var crypto = require('crypto');
 var fs = require('fs');
+var log = require('../core/logger')('util');
 var mmm = require('mmmagic');
 var path = require('path');
 var request = require('request');


### PR DESCRIPTION
I discovered the problem in local testing. The usage is in:
```
req.on('error', function(err) {
  log.error({'ctx': ctx, 'err': err}, 'Unable to download a file');
  ...
```