### PR TITLE
COL-1120, remove 'npm install' and 'gulp eslint' from buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,16 +9,16 @@ eb_codebuild_settings:
 phases:
   install:
     commands:
-      - npm install
+      - echo "install phase"
   pre_build:
     commands:
-      - ./node_modules/.bin/gulp jscs
+      - echo "pre_build phase"
   build:
     commands:
       - echo "build phase"
   post_build:
     commands:
-      - rm -Rf node_modules
+      - echo "post_build phase"
 
 artifacts:
   files:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1120

The same change was made (21 days ago) in SuiteC-land: https://github.com/ets-berkeley-edu/suitec/pull/570 