### PR TITLE
COL-1180, suitec-preview-service now uses aws-sdk v2.104.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "url": "git://github.com/ets-berkeley-edu/suitec-preview-service.git"
   },
   "dependencies": {
-    "aws-sdk": "2.88.0",
+    "aws-sdk": "2.104.0",
     "body-parser": "1.17.2",
     "bunyan": "2.0.0",
     "bunyan-prettystream": "0.1.3",
-    "config": "1.26.1",
+    "config": "1.26.2",
     "express": "4.15.3",
     "forever": "0.15.3",
     "gm": "1.23.0",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1180

aws-sdk changelog: https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md 

`config` upgraded, too.  SuiteC will get similar upgrades.