### PR TITLE
COL-1435 Work around node-gyp permission errors on Elastic Beanstalk

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Force npm to run node-gyp as root, preventing permission denied errors on Elastic Beanstalk
+unsafe-perm=true


### PR DESCRIPTION
See https://stackoverflow.com/questions/46001516/beanstalk-node-js-deployment-node-gyp-fails-due-to-permission-denied