### PR TITLE
NOJIRA v3.1 version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "preview-service",
-  "version": "1.2.2",
+  "version": "3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preview-service",
   "description": "Generates previews for SuiteC",
-  "version": "1.2.2",
+  "version": "3.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/suitec-preview-service.git"


### PR DESCRIPTION
Preview service version number will stay in sync with the rest of SuiteC going forward.