### PR TITLE
COL-1994, for 'link' assets, suitec-preview-service returns image_height in payload

### DIFF
--- a/lib/preview/link.js
+++ b/lib/preview/link.js
@@ -289,10 +289,12 @@ var processJamboard = function(ctx, jamboardUrl, callback) {
  */
 var processLink = function(ctx, link, callback) {
   var imagePath = path.join(ctx.directory, 'screenshot.jpg');
+  var defaultWidth = 1280;
+  var defaultHeight = 1280;
   var options = {
     'windowSize': {
-      'width': 1280,
-      'height': 1280
+      'width': defaultWidth,
+      'height': defaultHeight
     },
     'phantomConfig': {
       'ssl-protocol': 'any',
@@ -327,7 +329,8 @@ var processLink = function(ctx, link, callback) {
           'httpsEmbeddable': httpsEmbeddable,
           'httpEmbedUrl': httpEmbedUrl,
           'httpsEmbedUrl': httpsEmbedUrl,
-          'image_width': 1280
+          'image_width': defaultWidth,
+          'image_height': defaultHeight
         };
         var result = new Result(PreviewConstants.STATUS.DONE, thumbnailPath, imagePath, null, metadata);
         return callback(null, result);


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1994

See my comments in PR https://github.com/ets-berkeley-edu/squiggy/pull/694